### PR TITLE
added pixel mapper set method

### DIFF
--- a/src/c.rs
+++ b/src/c.rs
@@ -117,6 +117,13 @@ impl LedMatrixOptions {
         }
     }
 
+    pub fn set_pixel_mapper_config(&mut self, mapper: &str) {
+        unsafe {
+            let _ = CString::from_raw(self.pixel_mapper_config);
+            self.pixel_mapper_config = CString::new(mapper).unwrap().into_raw();
+        }
+    }
+
     pub fn set_hardware_pulsing(&mut self, enable: bool) {
         if enable {
             self.disable_hardware_pulsing = 0;


### PR DESCRIPTION
Hi,

I added and tested the pixel mapper set method so that Rotation and U-mapper mappers can be set.

Is there any chance of getting this fork merged into the original? So we can fetch from crates.io.

Thanks